### PR TITLE
support for unreal 4.24

### DIFF
--- a/environments/unreal_4.24.json
+++ b/environments/unreal_4.24.json
@@ -1,0 +1,5 @@
+{
+  "AVALON_UNREAL_PLUGIN": "{PYPE_ROOT}/repos/avalon-unreal-integration",
+  "PYPE_LOG_NO_COLORS": "True",
+  "QT_PREFERRED_BINDING": "PySide"
+}

--- a/launchers/unreal_4.24.toml
+++ b/launchers/unreal_4.24.toml
@@ -1,0 +1,8 @@
+executable = "unreal"
+schema = "avalon-core:application-1.0"
+application_dir = "unreal"
+label = "Unreal Editor 4.24"
+ftrack_label = "UnrealEditor"
+icon ="ue4_icon"
+launch_hook = "pype/hooks/unreal/unreal_prelaunch.py/UnrealPrelaunch"
+ftrack_icon = '{}/app_icons/ue4.png'

--- a/launchers/windows/unreal.bat
+++ b/launchers/windows/unreal.bat
@@ -1,0 +1,11 @@
+set __app__="Unreal Editor"
+set __exe__="%AVALON_CURRENT_UNREAL_ENGINE%\Engine\Binaries\Win64\UE4Editor.exe"
+if not exist %__exe__% goto :missing_app
+
+start %__app__% %__exe__% %PYPE_UNREAL_PROJECT_FILE% %*
+
+goto :eof
+
+:missing_app
+    echo ERROR: %__app__% not found in %__exe__%
+    exit /B 1

--- a/presets/unreal/project_setup.json
+++ b/presets/unreal/project_setup.json
@@ -1,0 +1,4 @@
+{
+  "dev_mode": false,
+  "install_unreal_python_engine": false
+}


### PR DESCRIPTION
# Pype Unreal Engine Integration

This PR adds support files for Unreal Engine integration. See more on [pypeclub/pype PR](https://github.com/pypeclub/pype/pull/3).

### Note about launchers
There is no need to set path to Unreal Engine as it is discovered by Pype. So only one `unreal.bat` or `unreal` shell script is needed.