### PR TITLE
bugfix/PYPE-768 blender launch from ftrack

### DIFF
--- a/launchers/blender_2.82.toml
+++ b/launchers/blender_2.82.toml
@@ -1,0 +1,7 @@
+application_dir = "blender"
+executable = "blender_2.82"
+schema = "avalon-core:application-1.0"
+label = "Blender 2.82"
+ftrack_label = "Blender"
+icon ="blender"
+ftrack_icon = '{}/app_icons/blender.png'

--- a/launchers/windows/blender_2.82.bat
+++ b/launchers/windows/blender_2.82.bat
@@ -1,0 +1,11 @@
+set __app__="Blender"
+set __exe__="C:\Program Files\Blender Foundation\Blender 2.82\blender.exe" --python-use-system-env
+if not exist %__exe__% goto :missing_app
+
+start %__app__% %__exe__% %*
+
+goto :eof
+
+:missing_app
+    echo ERROR: %__app__% not found in %__exe__%
+    exit /B 1


### PR DESCRIPTION
- added launchers for blender 2.82
    - main difference is that blender 2.82 requires to add argument `--python-use-system-env` to launch with entered PYTHONPATH and few other system environments