### PR TITLE
Feature/modify cloud mongo

### DIFF
--- a/environments/avalon.json
+++ b/environments/avalon.json
@@ -4,6 +4,7 @@
   "AVALON_USERNAME": "avalon",
   "AVALON_PASSWORD": "secret",
   "AVALON_DEBUG": "1",
+  "AVALON_MONGO": "mongodb://localhost:2707",
   "AVALON_DB": "avalon",
   "AVALON_DB_DATA": "{PYPE_SETUP_PATH}/../mongo_db_data",
   "AVALON_EARLY_ADOPTER": "1",

--- a/environments/global.json
+++ b/environments/global.json
@@ -33,6 +33,5 @@
         "linux": "{VIRTUAL_ENV}/Scripts/python",
         "darwin": "{VIRTUAL_ENV}/bin/python"
     },
-    "MONGO_URL": "mongodb://localhost:2707",
     "PYBLISH_GUI": "pyblish_pype"
 }


### PR DESCRIPTION
## Changes
- used `AVALON_MONGO` instead of `MONGO_URL` to not break more complex mongo url syntax

### Requires
- pype-setup
- pype
- pype-config
- avalon-core