### PR TITLE
Feature/module attributes in tray menu

### DIFF
--- a/presets/services/rest_api.json
+++ b/presets/services/rest_api.json
@@ -1,4 +1,0 @@
-{
-  "default_port": 8021,
-  "exclude_ports": []
-}

--- a/presets/services/timers_manager.json
+++ b/presets/services/timers_manager.json
@@ -1,6 +1,0 @@
-{
-    "timer":{
-        "full_time": 15,
-        "message_time": 0.5
-    }
-}

--- a/presets/tray/menu_items.json
+++ b/presets/tray/menu_items.json
@@ -12,6 +12,16 @@
         "Rest Api": true,
         "Premiere Communicator": true
     },
+    "attributes": {
+        "Rest Api": {
+          "default_port": 8021,
+          "exclude_ports": []
+        },
+        "Timers Manager": {
+            "full_time": 15,
+            "message_time": 0.5
+        }
+    },
     "item_import": [
         {
             "title": "User settings",


### PR DESCRIPTION
## Changes
- module attributes are defined next to module usage instead of separate presets for them

:black_flag: this depends on https://github.com/pypeclub/pype/pull/321
|---|