### PR TITLE
Redundant Maya launch hook

### DIFF
--- a/launchers/maya_2018.toml
+++ b/launchers/maya_2018.toml
@@ -9,7 +9,6 @@ executable = "maya2018"
 description = ""
 icon ="maya_icon"
 ftrack_icon = '{}/app_icons/maya.png'
-launch_hook = "pype/hooks/maya/prelaunch.py/MayaPrelaunchHook"
 
 [copy]
 "{PYPE_MODULE_ROOT}/pype/resources/maya/workspace.mel" = "workspace.mel"

--- a/launchers/maya_2019.toml
+++ b/launchers/maya_2019.toml
@@ -9,7 +9,6 @@ executable = "maya2019"
 description = ""
 icon ="maya_icon"
 ftrack_icon = '{}/app_icons/maya.png'
-launch_hook = "pype/hooks/maya/prelaunch.py/MayaPrelaunchHook"
 
 [copy]
 "{PYPE_MODULE_ROOT}/pype/resources/maya/workspace.mel" = "workspace.mel"

--- a/launchers/maya_2020.toml
+++ b/launchers/maya_2020.toml
@@ -9,7 +9,6 @@ executable = "maya2020"
 description = ""
 icon ="maya_icon"
 ftrack_icon = '{}/app_icons/maya.png'
-launch_hook = "pype/hooks/maya/prelaunch.py/MayaPrelaunchHook"
 
 [copy]
 "{PYPE_MODULE_ROOT}/pype/resources/maya/workspace.mel" = "workspace.mel"


### PR DESCRIPTION
`toml` files are referencing non-existent files.