### PR TITLE
Harmony launch on linux/mac with other user

### DIFF
--- a/launchers/darwin/harmony_17
+++ b/launchers/darwin/harmony_17
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 DIRNAME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 set >~/environment.tmp
+if [ $? -ne -0 ] ; threading
+  echo "ERROR: cannot write to '~/environment.tmp'!"
+  read -n 1 -s -r -p "Press any key to exit"
+  return
+fi
 open -a Terminal.app "$DIRNAME/harmony_17_launch"


### PR DESCRIPTION
## Problem

When Pype is run with different user accout via terminal (for example using *sudo*), all files created by it will have ownership of that user. If you run Pype then with other user (or withou *sudo*), those file cannot be deleted or written. Usually those cases will fail with `permission denied` errors and give user idea on whats happening.

This is not case with mac Harmony launcher that is writing environment variables into `~/environment.tmp`, If that file already exists but is inaccessible, writing of new enviornment will fail silently and Harmony will open in wrong context.

## Fix

This fix will check if we succeeded writing and if not, we print error and exit after user presses any key.