### PR TITLE
Bugfix/wrong module name

### DIFF
--- a/presets/tray/menu_items.json
+++ b/presets/tray/menu_items.json
@@ -10,7 +10,7 @@
         "Idle Manager": true,
         "Timers Manager": true,
         "Rest Api": true,
-        "Premiere Communicator": true
+        "Adobe Communicator": true
     },
     "attributes": {
         "Rest Api": {


### PR DESCRIPTION
## Issue
Module `Adobe Communicator` is not in menu_items so is used all the time.

## Changes
Module `Premiere Communicator` renamed to `Adobe Communicator`