### PR TITLE
Fix spelling of omitted status in ftrack_config

### DIFF
--- a/presets/ftrack/ftrack_config.json
+++ b/presets/ftrack/ftrack_config.json
@@ -4,7 +4,7 @@
     },
 
     "status_update": {
-        "_ignore_": ["in progress", "ommited", "on hold"],
+        "_ignore_": ["in progress", "omitted", "on hold"],
         "Ready": ["not ready"],
         "In Progress" : ["_any_"]
     },


### PR DESCRIPTION
Fixed a typo/misspell of ftrack_config.json from "ommited" to "omitted"