### PR TITLE
Bugfix/blender launch fix

### DIFF
--- a/environments/blender.json
+++ b/environments/blender.json
@@ -3,5 +3,6 @@
     "PYTHONPATH": [
         "{PYPE_SETUP_PATH}/repos/avalon-core/setup/blender",
         "{PYTHONPATH}"
-      ]
+    ],
+    "CREATE_NEW_CONSOLE": "yes"
 }


### PR DESCRIPTION
## Issue
- Blender is not launched

## Changes
- blender has set env `"CREATE_NEW_CONSOLE"` so created subprocess is created in proper way for blender on windows