### PR TITLE
Centos support

### DIFF
--- a/environments/global.json
+++ b/environments/global.json
@@ -37,7 +37,7 @@
     "PYPE_PROJECT_CONFIGS": "{PYPE_SETUP_PATH}/../studio-project-configs",
     "PYPE_PYTHON_EXE": {
         "windows": "{VIRTUAL_ENV}/Scripts/python.exe",
-        "linux": "{VIRTUAL_ENV}/Scripts/python",
+        "linux": "{VIRTUAL_ENV}/bin/python3",
         "darwin": "{VIRTUAL_ENV}/bin/python"
     },
     "PYBLISH_GUI": "pyblish_pype",

--- a/environments/global.json
+++ b/environments/global.json
@@ -40,6 +40,11 @@
         "linux": "{VIRTUAL_ENV}/bin/python3",
         "darwin": "{VIRTUAL_ENV}/bin/python"
     },
+    "PYPE_SITE_PACKAGES": {
+      "windows": "{VIRTUAL_ENV}/Lib/site-packages",
+      "linux": "{VIRTUAL_ENV}/lib/python{PYTHON_VERSION}/site-packages",
+      "darwin": "{VIRTUAL_ENV}/lib/python{PYTHON_VERSION}/site-packages"
+    },
     "PYBLISH_GUI": "pyblish_pype",
     "PYPE_OIIO_PATH": "{PYPE_SETUP_PATH}/vendor/bin/oiiotool/windows/oiiotool"
 }


### PR DESCRIPTION
## Description
- fixed default path to linux python in `PYPE_PYTHON_EXE`
- added env variable `PYPE_SITE_PACKAGES` pointing to pype's venv site-packages directory (because of `ruamel.yaml` module)

|:black_flag: |this depends on|
|---|---|
|pype-setup|https://github.com/pypeclub/pype-setup/pull/77|
|pype|https://github.com/pypeclub/pype/pull/683|