### PR TITLE
#731 - better handling of missing presets

### DIFF
--- a/presets/sync_server/config.json
+++ b/presets/sync_server/config.json
@@ -1,5 +1,7 @@
 {
   "local_id": "local_0",
   "retry_cnt": 3,
-  "loop_delay": 60
+  "loop_delay": 60,
+  "active_site": "studio",
+  "remote_site": "gdrive"
 }


### PR DESCRIPTION
Added missed support for active sites.
('active_site' - mine, 'remote_site' - theirs, sync destination)

Requires:
pypeclub/pype#734