### PR TITLE
Shot asset build trigger status

### DIFF
--- a/presets/ftrack/plugins/server.json
+++ b/presets/ftrack/plugins/server.json
@@ -1,1 +1,17 @@
-{}
+{
+    "TaskStatusToParent": {
+        "parent_types": ["shot", "asset build"],
+        "parent_status_match_all_task_statuses": [
+            {
+                "new_status": "completed",
+                "task_statuses": ["approved", "omitted"]
+            }
+        ],
+        "parent_status_by_task_status": [
+            {
+                "new_status": "working",
+                "task_statuses": ["in progress"]
+            }
+        ]
+    }
+}

--- a/presets/ftrack/plugins/server.json
+++ b/presets/ftrack/plugins/server.json
@@ -9,7 +9,7 @@
         ],
         "parent_status_by_task_status": [
             {
-                "new_status": "working",
+                "new_status": "in progress",
                 "task_statuses": ["in progress"]
             }
         ]


### PR DESCRIPTION
## Changes
- added defaults for event handler `TaskStatusToParent`

|:black_flag: |this depends on|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/736|
