### PR TITLE
Blender: Linux launcher, Qt environment fix

### DIFF
--- a/environments/blender.json
+++ b/environments/blender.json
@@ -4,5 +4,6 @@
         "{PYPE_SETUP_PATH}/repos/avalon-core/setup/blender",
         "{PYTHONPATH}"
     ],
-    "CREATE_NEW_CONSOLE": "yes"
+    "CREATE_NEW_CONSOLE": "yes",
+    "QT_PREFERRED_BINDING": "PySide2"
 }

--- a/launchers/linux/blender_2.83
+++ b/launchers/linux/blender_2.83
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# this is used for debugging Blender
+# BLENDER_ENV_FILE="~/.blender-env.tmp"
+# echo "saving environment to $BLENDER_ENV_FILE"
+# set > ~/.blender-env.tmp
+# gnome-terminal -t Blender -x bash -c "cat $BLENDER_ENV_FILE;source $BLENDER_ENV_FILE && rm $BLENDER_ENV_FILE;/var/lib/snapd/snap/bin/blender -d --verbose 3 --python-use-system-env"
+
+# but you can call directly blender executable if you are not interested
+blender --python-use-system-env


### PR DESCRIPTION
## Bugfig and Feature

added blender launcher for linux and `QT_PREFERRED_BINDING` environment set to PySide2 for Blender