### PR TITLE
Optionally add task to subset name

### DIFF
--- a/presets/tools/creator_subset_name_profiles.json
+++ b/presets/tools/creator_subset_name_profiles.json
@@ -1,0 +1,14 @@
+[
+    {
+        "families": [],
+        "hosts": [],
+        "tasks": [],
+        "template": "{family}{Variant}"
+    },
+    {
+        "families": ["render"],
+        "hosts": [],
+        "tasks": [],
+        "template": "{family}{Task}{Variant}"
+    }
+]


### PR DESCRIPTION
## Changes
- added default values for subset name templates profiling

|:black_flag: |this depends on|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1072|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/289|